### PR TITLE
Offline buffering: Limit number of persisted items

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ std::unique_ptr<wolkabout::Wolk> wolk =
     wolk->connect();
 ```
 
-Where 'CustomPersistServiceImplemenation' is implementation of wolkabout::PersistService interface.
+For more info on persistence mechanism see wolkabout::PersistService and wolkabout::JsonPersistService classes

--- a/src/service/persist/PersistService.cpp
+++ b/src/service/persist/PersistService.cpp
@@ -21,7 +21,9 @@
 
 namespace wolkabout
 {
-PersistService::PersistService(std::string persistPath)
+PersistService::PersistService(std::string persistPath, unsigned long long int maximumNumberOfPersistedItems,
+                               bool isCircular)
+: m_maximumNumberOfPersistedReadings(maximumNumberOfPersistedItems), m_isCircular(isCircular)
 {
     if (m_persistPath.back() != '\\' && m_persistPath.back() != '/')
     {
@@ -29,6 +31,16 @@ PersistService::PersistService(std::string persistPath)
     }
 
     m_persistPath = persistPath;
+}
+
+unsigned long long PersistService::getMaximumNumberOfPersistedReadings()
+{
+    return m_maximumNumberOfPersistedReadings;
+}
+
+bool PersistService::isCircular()
+{
+    return m_isCircular;
 }
 
 const std::string& PersistService::getPersistPath() const

--- a/src/service/persist/PersistService.cpp
+++ b/src/service/persist/PersistService.cpp
@@ -33,12 +33,12 @@ PersistService::PersistService(std::string persistPath, unsigned long long int m
     m_persistPath = persistPath;
 }
 
-unsigned long long PersistService::getMaximumNumberOfPersistedReadings()
+unsigned long long PersistService::getMaximumNumberOfPersistedReadings() const
 {
     return m_maximumNumberOfPersistedReadings;
 }
 
-bool PersistService::isCircular()
+bool PersistService::isCircular() const
 {
     return m_isCircular;
 }

--- a/src/service/persist/PersistService.h
+++ b/src/service/persist/PersistService.h
@@ -74,14 +74,14 @@ public:
      * @brief getMaximumNumberOfPersistedReadings Returns maximum number of persisted readings
      * @return Maximum number of reading items
      */
-    unsigned long long int getMaximumNumberOfPersistedReadings();
+    unsigned long long int getMaximumNumberOfPersistedReadings() const;
 
     /**
      * @brief isCircular Returns whether persistence acts as circular
      * @return true if persistence acts as circular buffer, eg. overwrites oldest when maximumNumberOfPersistedItems is
      * reached
      */
-    bool isCircular();
+    bool isCircular() const;
 
     /**
      * @brief Returns path to directory used by persistence

--- a/src/service/persist/PersistService.h
+++ b/src/service/persist/PersistService.h
@@ -32,8 +32,15 @@ public:
     /**
      * @brief Constructor
      * @param persistPath Relative, or absolute, path to directory to be used with persistence implementation
+     * @param maximumNumberOfPersistedItems This many items will be kept in persistence.<br>
+     *                                      Passing N will limit persistence to keep N sensor readings, and N alarms,
+     *                                      Actuator statuses are not limited by this parameter, since ActuatorStatus-es
+     *                                      do not have history latest actuator statuses are persisted always
+     * @param isCircular True if persistence should act as circular buffer, eg. overwrite oldest sensor reaading or
+     * alarm when maximumNumberOfPersistedItems is reached
      */
-    PersistService(std::string persistPath = "");
+    PersistService(std::string persistPath = "", unsigned long long int maximumNumberOfPersistedItems = 0,
+                   bool isCircular = false);
 
     /**
      * @brief Destructor
@@ -64,12 +71,27 @@ public:
     virtual void dropFirst() = 0;
 
     /**
+     * @brief getMaximumNumberOfPersistedReadings Returns maximum number of persisted readings
+     * @return Maximum number of reading items
+     */
+    unsigned long long int getMaximumNumberOfPersistedReadings();
+
+    /**
+     * @brief isCircular Returns whether persistence acts as circular
+     * @return true if persistence acts as circular buffer, eg. overwrites oldest when maximumNumberOfPersistedItems is
+     * reached
+     */
+    bool isCircular();
+
+    /**
      * @brief Returns path to directory used by persistence
      * @return çonst std::string& containing path to directory used by persistence
      */
     const std::string& getPersistPath() const;
 
 private:
+    unsigned long long int m_maximumNumberOfPersistedReadings;
+    bool m_isCircular;
     std::string m_persistPath;
 };
 }

--- a/src/service/persist/json/JsonPersistService.cpp
+++ b/src/service/persist/json/JsonPersistService.cpp
@@ -32,67 +32,60 @@
 
 namespace wolkabout
 {
-JsonPersistService::JsonPersistService(std::string persistPath) : PersistService(std::move(persistPath))
+JsonPersistService::JsonPersistService(std::string persistPath, unsigned long long maximumNumberOfPersistedItems,
+                                       bool isCircular)
+: PersistService(std::move(persistPath), maximumNumberOfPersistedItems, isCircular)
 {
     FileSystemUtils::createDirectory(PersistService::getPersistPath());
+    FileSystemUtils::createDirectory(PersistService::getPersistPath() + ACTUATOR_STATUS_DIRECTORY);
+    FileSystemUtils::createDirectory(PersistService::getPersistPath() + SENSOR_READING_DIRECTORY);
+    FileSystemUtils::createDirectory(PersistService::getPersistPath() + ALARM_DIRECTORY);
 
-    getPersistedReadingsList(true);
+    getPersistedItemsFilenames(true);
 }
 
 bool JsonPersistService::hasPersistedReadings()
 {
-    return !getPersistedReadingsList().empty();
+    return !getPersistedActuatorStatusFilenames().empty() || !getPersistedSensorReadingFilenames().empty() ||
+           !getPersistedAlarmFilenames().empty();
 }
 
 void JsonPersistService::persist(std::shared_ptr<Reading> reading)
 {
-    std::string name = PersistService::getPersistPath() + generateFileName(reading);
-    std::string content = JsonPersistServiceParser::toJson(*reading);
+    class ReadingPersisterVisitor final : public ReadingVisitor
+    {
+    public:
+        ReadingPersisterVisitor(JsonPersistService& persistService) : m_persistService(persistService) {}
+        ~ReadingPersisterVisitor() = default;
 
-    FileSystemUtils::createFileWithContent(name, content);
-    invalidateCachedReadingsList();
+        void visit(ActuatorStatus& actuatorStatus) override { m_persistService.persist(actuatorStatus); }
+
+        void visit(Alarm& alarm) override { m_persistService.persist(alarm); }
+
+        void visit(SensorReading& sensorReading) override { m_persistService.persist(sensorReading); }
+
+    private:
+        JsonPersistService& m_persistService;
+    } readingSerializerVisitor(*this);
+    reading->acceptVisit(readingSerializerVisitor);
 }
 
 std::shared_ptr<Reading> JsonPersistService::unpersistFirst()
 {
-    const std::vector<std::string>& readings = getPersistedReadingsList();
-    const std::string& firstReading = readings.front();
+    const std::vector<std::string>& readings = getPersistedItemsFilenames();
+    const std::string& readingFile = readings.front();
 
-    std::string readingJson;
-    if (!FileSystemUtils::readFileContent(PersistService::getPersistPath() + firstReading, readingJson))
+    if (StringUtils::contains(readingFile, ACTUATOR_STATUS_DIRECTORY))
     {
-        return nullptr;
+        return unpersistActuatorStatus(readingFile);
     }
-
-    if (StringUtils::endsWith(firstReading, ACTUATOR_STATUS_SUFFIX))
+    else if (StringUtils::contains(readingFile, SENSOR_READING_DIRECTORY))
     {
-        ActuatorStatus actuatorStatus;
-        if (!JsonPersistServiceParser::fromJson(readingJson, actuatorStatus))
-        {
-            return nullptr;
-        }
-
-        return std::make_shared<ActuatorStatus>(actuatorStatus);
+        return unpersistSensorReading(readingFile);
     }
-    else if (StringUtils::endsWith(firstReading, ALARM_SUFFIX))
+    else if (StringUtils::contains(readingFile, ALARM_DIRECTORY))
     {
-        Alarm alarm;
-        if (!JsonPersistServiceParser::fromJson(readingJson, alarm))
-        {
-            return nullptr;
-        }
-
-        return std::make_shared<Alarm>(alarm);
-    }
-    else if (StringUtils::endsWith(firstReading, SENSOR_READING_SUFFIX))
-    {
-        SensorReading sensorReading;
-        if (!JsonPersistServiceParser::fromJson(readingJson, sensorReading))
-        {
-            return nullptr;
-        }
-
-        return std::make_shared<SensorReading>(sensorReading);
+        return unpersistAlarm(readingFile);
     }
 
     return nullptr;
@@ -100,67 +93,288 @@ std::shared_ptr<Reading> JsonPersistService::unpersistFirst()
 
 void JsonPersistService::dropFirst()
 {
-    const std::vector<std::string>& readings = getPersistedReadingsList();
-    FileSystemUtils::deleteFile(PersistService::getPersistPath() + readings.front());
+    const std::vector<std::string>& readings = getPersistedItemsFilenames();
+    const std::string& firstReading = readings.front();
 
-    invalidateCachedReadingsList();
+    FileSystemUtils::deleteFile(firstReading);
+
+    invalidatePersistedItemsCache();
 }
 
-std::string JsonPersistService::generateFileName(std::shared_ptr<Reading> reading)
+void JsonPersistService::persist(const ActuatorStatus& actuatorStatus)
 {
-    struct ReadingPostfixGeneratorVisitor final : public ReadingVisitor
+    std::string name = generateFileName(actuatorStatus);
+    std::string content = JsonPersistServiceParser::toJson(actuatorStatus);
+
+    FileSystemUtils::createFileWithContent(name, content);
+    invalidatePersistedItemsCache();
+}
+
+void JsonPersistService::persist(const SensorReading& sensorReading)
+{
+    if (PersistService::getMaximumNumberOfPersistedReadings() != 0 &&
+        getPersistedSensorReadingFilenames().size() >= PersistService::getMaximumNumberOfPersistedReadings())
     {
-        ReadingPostfixGeneratorVisitor(JsonPersistService& jjsonPersistService, Reading& rreading)
-        : jsonPersistService(jjsonPersistService), reading(rreading), filename("")
+        if (PersistService::isCircular())
         {
+            FileSystemUtils::deleteFile(getPersistedSensorReadingFilenames().front());
         }
-        ~ReadingPostfixGeneratorVisitor() = default;
-
-        void visit(ActuatorStatus& actuatorStatus) override
+        else
         {
-            filename = actuatorStatus.getReference() + ACTUATOR_STATUS_SUFFIX;
+            return;
         }
-
-        void visit(Alarm&) override
-        {
-            filename = std::to_string(jsonPersistService.getLastPersistedReadingNumber() + 1) + ALARM_SUFFIX;
-        }
-
-        void visit(SensorReading&) override
-        {
-            filename = std::to_string(jsonPersistService.getLastPersistedReadingNumber() + 1) + SENSOR_READING_SUFFIX;
-        }
-
-        JsonPersistService& jsonPersistService;
-        Reading& reading;
-        std::string filename;
-    } readingPostfixGeneratorVisitor = {*this, *reading};
-    reading->acceptVisit(readingPostfixGeneratorVisitor);
-
-    return readingPostfixGeneratorVisitor.filename;
-}
-
-unsigned long long int JsonPersistService::getLastPersistedReadingNumber()
-{
-    return getPersistedReadingsList().size();
-}
-
-const std::vector<std::string>& JsonPersistService::getPersistedReadingsList(bool ignoreCached)
-{
-    if (ignoreCached || std::get<CachedReadingsListIsDirty>(m_cachedReadingsList))
-    {
-        std::vector<std::string> readings = FileSystemUtils::listFiles(PersistService::getPersistPath());
-        std::sort(readings.begin(), readings.end());
-
-        std::get<CachedReadingsList>(m_cachedReadingsList) = readings;
-        std::get<CachedReadingsListIsDirty>(m_cachedReadingsList) = false;
     }
 
-    return std::get<CachedReadingsList>(m_cachedReadingsList);
+    std::string name = generateFileName(sensorReading);
+    std::string content = JsonPersistServiceParser::toJson(sensorReading);
+
+    FileSystemUtils::createFileWithContent(name, content);
+    invalidatePersistedItemsCache();
 }
 
-void JsonPersistService::invalidateCachedReadingsList()
+void JsonPersistService::persist(const Alarm& alarm)
 {
-    std::get<CachedReadingsListIsDirty>(m_cachedReadingsList) = true;
+    if (PersistService::getMaximumNumberOfPersistedReadings() != 0 &&
+        getPersistedAlarmFilenames().size() >= PersistService::getMaximumNumberOfPersistedReadings())
+    {
+        if (PersistService::isCircular())
+        {
+            FileSystemUtils::deleteFile(getPersistedAlarmFilenames().front());
+        }
+        else
+        {
+            return;
+        }
+    }
+
+    std::string name = generateFileName(alarm);
+    std::string content = JsonPersistServiceParser::toJson(alarm);
+
+    FileSystemUtils::createFileWithContent(name, content);
+    invalidatePersistedItemsCache();
+}
+
+std::shared_ptr<Reading> JsonPersistService::unpersistActuatorStatus(const std::string& readingFile)
+{
+    std::string readingJson;
+    if (!FileSystemUtils::readFileContent(readingFile, readingJson))
+    {
+        return nullptr;
+    }
+
+    ActuatorStatus actuatorStatus;
+    if (!JsonPersistServiceParser::fromJson(readingJson, actuatorStatus))
+    {
+        return nullptr;
+    }
+
+    return std::make_shared<ActuatorStatus>(actuatorStatus);
+}
+
+std::shared_ptr<Reading> JsonPersistService::unpersistSensorReading(const std::string& readingFile)
+{
+    std::string readingJson;
+    if (!FileSystemUtils::readFileContent(readingFile, readingJson))
+    {
+        return nullptr;
+    }
+
+    SensorReading sensorReading;
+    if (!JsonPersistServiceParser::fromJson(readingJson, sensorReading))
+    {
+        return nullptr;
+    }
+
+    return std::make_shared<SensorReading>(sensorReading);
+}
+
+std::shared_ptr<Reading> JsonPersistService::unpersistAlarm(const std::string& readingFile)
+{
+    std::string readingJson;
+    if (!FileSystemUtils::readFileContent(readingFile, readingJson))
+    {
+        return nullptr;
+    }
+
+    Alarm alarm;
+    if (!JsonPersistServiceParser::fromJson(readingJson, alarm))
+    {
+        return nullptr;
+    }
+
+    return std::make_shared<Alarm>(alarm);
+}
+
+std::string JsonPersistService::generateFileName(const ActuatorStatus& actuatorStatus)
+{
+    return PersistService::getPersistPath() + ACTUATOR_STATUS_DIRECTORY + actuatorStatus.getReference();
+}
+
+std::string JsonPersistService::generateFileName(const SensorReading& sensorReading)
+{
+    unsigned long long readingNumber = 0;
+    const std::vector<std::string>& sensorReadings = getPersistedSensorReadingFilenames();
+    if (sensorReadings.size() != 0)
+    {
+        const std::string& lastReading = sensorReadings.back();
+
+        try
+        {
+            readingNumber = std::stoull(StringUtils::tokenize(lastReading, "/").back());
+        }
+        catch (std::invalid_argument&)
+        {
+            FileSystemUtils::deleteFile(lastReading);
+            invalidatePersistedItemsCache();
+            return generateFileName(sensorReading);
+        }
+    }
+
+    return PersistService::getPersistPath() + SENSOR_READING_DIRECTORY + std::to_string(readingNumber + 1) + "-" +
+           sensorReading.getReference();
+}
+
+std::string JsonPersistService::generateFileName(const Alarm& alarm)
+{
+    unsigned long long alarmNumber = 0;
+    const std::vector<std::string>& alarms = getPersistedAlarmFilenames();
+    if (alarms.size() != 0)
+    {
+        const std::string& lastAlarm = alarms.back();
+        try
+        {
+            alarmNumber = std::stoull(StringUtils::tokenize(lastAlarm, "/").back());
+        }
+        catch (std::invalid_argument&)
+        {
+            FileSystemUtils::deleteFile(lastAlarm);
+            invalidatePersistedItemsCache();
+            return generateFileName(alarm);
+        }
+    }
+
+    return PersistService::getPersistPath() + ALARM_DIRECTORY + std::to_string(alarmNumber + 1) + "-" +
+           alarm.getReference();
+}
+
+const std::vector<std::string>& JsonPersistService::getPersistedActuatorStatusFilenames(bool forceCacheReload)
+{
+    if (forceCacheReload || std::get<PersistedItemsListIsDirty>(m_cachedActuatorStatusFilenames))
+    {
+        std::vector<std::string> actuatorStatuses;
+        for (const std::string& actuatorStatus :
+             FileSystemUtils::listFiles(PersistService::getPersistPath() + ACTUATOR_STATUS_DIRECTORY))
+        {
+            actuatorStatuses.emplace_back(PersistService::getPersistPath() + ACTUATOR_STATUS_DIRECTORY +
+                                          actuatorStatus);
+        }
+
+        std::sort(actuatorStatuses.begin(), actuatorStatuses.end(),
+                  [](const std::string& firstFilename, const std::string& secondFilename) -> bool {
+                      try
+                      {
+                          auto a = std::stoull(StringUtils::tokenize(firstFilename, "/").back());
+                          auto b = std::stoull(StringUtils::tokenize(secondFilename, "/").back());
+
+                          return a < b;
+                      }
+                      catch (std::invalid_argument&)
+                      {
+                          return false;
+                      }
+                  });
+
+        std::get<PersistedItemsList>(m_cachedActuatorStatusFilenames) = std::move(actuatorStatuses);
+        std::get<PersistedItemsListIsDirty>(m_cachedActuatorStatusFilenames) = false;
+    }
+
+    return std::get<PersistedItemsList>(m_cachedActuatorStatusFilenames);
+}
+
+const std::vector<std::string>& JsonPersistService::getPersistedSensorReadingFilenames(bool forceCacheReload)
+{
+    if (forceCacheReload || std::get<PersistedItemsListIsDirty>(m_cachedSensorReadingFilenames))
+    {
+        std::vector<std::string> sensorReadings;
+        for (const std::string& sensorReading :
+             FileSystemUtils::listFiles(PersistService::getPersistPath() + SENSOR_READING_DIRECTORY))
+        {
+            sensorReadings.emplace_back(PersistService::getPersistPath() + SENSOR_READING_DIRECTORY + sensorReading);
+        }
+
+        std::sort(sensorReadings.begin(), sensorReadings.end(),
+                  [](const std::string& firstFilename, const std::string& secondFilename) -> bool {
+                      try
+                      {
+                          auto a = std::stoull(StringUtils::tokenize(firstFilename, "/").back());
+                          auto b = std::stoull(StringUtils::tokenize(secondFilename, "/").back());
+
+                          return a < b;
+                      }
+                      catch (std::invalid_argument&)
+                      {
+                          return false;
+                      }
+                  });
+
+        std::get<PersistedItemsList>(m_cachedSensorReadingFilenames) = std::move(sensorReadings);
+        std::get<PersistedItemsListIsDirty>(m_cachedSensorReadingFilenames) = false;
+    }
+
+    return std::get<PersistedItemsList>(m_cachedSensorReadingFilenames);
+}
+
+const std::vector<std::string>& JsonPersistService::getPersistedAlarmFilenames(bool forceCacheReload)
+{
+    if (forceCacheReload || std::get<PersistedItemsListIsDirty>(m_cachedAlarmFilenames))
+    {
+        std::vector<std::string> alarms;
+        for (const std::string& alarm : FileSystemUtils::listFiles(PersistService::getPersistPath() + ALARM_DIRECTORY))
+        {
+            alarms.emplace_back(PersistService::getPersistPath() + ALARM_DIRECTORY + alarm);
+        }
+
+        std::sort(alarms.begin(), alarms.end(),
+                  [](const std::string& firstFilename, const std::string& secondFilename) -> bool {
+                      try
+                      {
+                          auto a = std::stoull(StringUtils::tokenize(firstFilename, "/").back());
+                          auto b = std::stoull(StringUtils::tokenize(secondFilename, "/").back());
+
+                          return a < b;
+                      }
+                      catch (std::invalid_argument&)
+                      {
+                          return false;
+                      }
+                  });
+
+        std::get<PersistedItemsList>(m_cachedAlarmFilenames) = std::move(alarms);
+        std::get<PersistedItemsListIsDirty>(m_cachedAlarmFilenames) = false;
+    }
+
+    return std::get<PersistedItemsList>(m_cachedAlarmFilenames);
+}
+
+std::vector<std::string> JsonPersistService::getPersistedItemsFilenames(bool forceCacheReload)
+{
+    std::vector<std::string> files;
+    auto alarms = getPersistedAlarmFilenames(forceCacheReload);
+    files.insert(files.end(), alarms.begin(), alarms.end());
+
+    auto actuatorStatuses = getPersistedActuatorStatusFilenames(forceCacheReload);
+    files.insert(files.end(), actuatorStatuses.begin(), actuatorStatuses.end());
+
+    auto sensorReadings = getPersistedSensorReadingFilenames(forceCacheReload);
+    files.insert(files.end(), sensorReadings.begin(), sensorReadings.end());
+
+    return files;
+}
+
+void JsonPersistService::invalidatePersistedItemsCache()
+{
+    std::get<PersistedItemsListIsDirty>(m_cachedActuatorStatusFilenames) = true;
+    std::get<PersistedItemsListIsDirty>(m_cachedSensorReadingFilenames) = true;
+    std::get<PersistedItemsListIsDirty>(m_cachedAlarmFilenames) = true;
 }
 }

--- a/src/utilities/StringUtils.cpp
+++ b/src/utilities/StringUtils.cpp
@@ -26,6 +26,11 @@ bool StringUtils::contains(const std::string& string, char c)
     return string.find(c) != std::string::npos;
 }
 
+bool StringUtils::contains(const std::string& string, const std::string& substring)
+{
+    return string.find(substring) != std::string::npos;
+}
+
 std::vector<std::string> StringUtils::tokenize(const std::string& string, const std::string& delimiters)
 {
     std::vector<std::string> tokens;

--- a/src/utilities/StringUtils.h
+++ b/src/utilities/StringUtils.h
@@ -29,6 +29,8 @@ public:
 
     static bool contains(const std::string& string, char c);
 
+    static bool contains(const std::string& string, const std::string& substring);
+
     static std::vector<std::string> tokenize(const std::string& string, const std::string& delimiters);
 
     static bool endsWith(const std::string& string, const std::string& suffix);

--- a/src/utilities/json.hpp
+++ b/src/utilities/json.hpp
@@ -12403,5 +12403,4 @@ inline nlohmann::json::json_pointer operator"" _json_pointer(const char* s, std:
 #undef JSON_DEPRECATED
 #undef JSON_THROW
 #undef JSON_TRY
-
 #endif


### PR DESCRIPTION
service/persist/json/JsonPersistService:
Actuator statuses, sensor readings, and alarms are persisted to separate directories
Number of persisted items can be limited
Service can act as circular buffer and overwrite oldest readings if desired

README.md:
Added see more for persistence mechanism

utilities/StringUtils:
Extended with 'contains' function