### PR TITLE
Added 1s delay before an attempt to reconnect

### DIFF
--- a/src/Wolk.cpp
+++ b/src/Wolk.cpp
@@ -131,6 +131,7 @@ void Wolk::connect()
     addToCommandBuffer([=]() -> void {
         if (!m_connectivityService->connect())
         {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
             connect();
             return;
         }


### PR DESCRIPTION
This is the second part to fix the issue #34.
The first part of this fix is in WolkSDK